### PR TITLE
feat: AsyncAPI 2.6.0 - EAP-2

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/asyncapi/generator/AsyncApiCodeGenerator.java
+++ b/deployment/src/main/java/io/quarkiverse/asyncapi/generator/AsyncApiCodeGenerator.java
@@ -12,7 +12,7 @@ import java.util.Optional;
 
 import org.eclipse.microprofile.config.Config;
 
-import com.asyncapi.v2.model.AsyncAPI;
+import com.asyncapi.v2._6_0.model.AsyncAPI;
 
 import io.quarkiverse.asyncapi.config.AsyncAPIUtils;
 import io.quarkiverse.asyncapi.config.ObjectMapperFactory;

--- a/integration-tests/simple/src/test/java/io/quarkiverse/asyncapi/config/AsyncAPIResourceGeneratorTest.java
+++ b/integration-tests/simple/src/test/java/io/quarkiverse/asyncapi/config/AsyncAPIResourceGeneratorTest.java
@@ -9,7 +9,7 @@ import javax.inject.Inject;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.junit.jupiter.api.Test;
 
-import com.asyncapi.v2.model.AsyncAPI;
+import com.asyncapi.v2._6_0.model.AsyncAPI;
 
 import io.quarkus.test.junit.QuarkusTest;
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus.version>2.15.0.Final</quarkus.version>
     <version.org.assertj>3.23.1</version.org.assertj>
-    <version.asyncapi.core>1.0.0-EAP-1</version.asyncapi.core>
+    <version.asyncapi.core>1.0.0-EAP-2</version.asyncapi.core>
     <version.com.fasterxml.jackson>2.14.1</version.com.fasterxml.jackson>
     <version.org.projectlombok>1.18.24</version.org.projectlombok>
   </properties>

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/AsyncAPIRegistry.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/AsyncAPIRegistry.java
@@ -2,7 +2,7 @@ package io.quarkiverse.asyncapi.config;
 
 import java.util.Optional;
 
-import com.asyncapi.v2.model.AsyncAPI;
+import com.asyncapi.v2._6_0.model.AsyncAPI;
 
 /** Holder of Async API instances */
 public interface AsyncAPIRegistry {

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/AsyncAPISupplier.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/AsyncAPISupplier.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.asyncapi.config;
 
-import com.asyncapi.v2.model.AsyncAPI;
+import com.asyncapi.v2._6_0.model.AsyncAPI;
 
 public interface AsyncAPISupplier {
     String id();

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/AsyncConfigSource.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/AsyncConfigSource.java
@@ -7,9 +7,9 @@ import java.util.Map.Entry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.asyncapi.v2.model.AsyncAPI;
-import com.asyncapi.v2.model.channel.ChannelItem;
-import com.asyncapi.v2.model.server.Server;
+import com.asyncapi.v2._6_0.model.AsyncAPI;
+import com.asyncapi.v2._6_0.model.channel.ChannelItem;
+import com.asyncapi.v2._6_0.model.server.Server;
 
 import io.quarkiverse.asyncapi.config.channels.ChannelConfigurer;
 import io.quarkiverse.asyncapi.config.channels.ChannelConfigurerFactory;

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/JacksonAsyncAPISupplier.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/JacksonAsyncAPISupplier.java
@@ -3,7 +3,7 @@ package io.quarkiverse.asyncapi.config;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 
-import com.asyncapi.v2.model.AsyncAPI;
+import com.asyncapi.v2._6_0.model.AsyncAPI;
 
 public abstract class JacksonAsyncAPISupplier implements AsyncAPISupplier {
 

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/MapAsyncAPIRegistry.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/MapAsyncAPIRegistry.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 
-import com.asyncapi.v2.model.AsyncAPI;
+import com.asyncapi.v2._6_0.model.AsyncAPI;
 
 public class MapAsyncAPIRegistry implements AsyncAPIRegistry {
     private final Map<String, AsyncAPI> map;

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/AbstractChannelConfigurer.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/AbstractChannelConfigurer.java
@@ -2,9 +2,9 @@ package io.quarkiverse.asyncapi.config.channels;
 
 import java.util.Map;
 
-import com.asyncapi.v2.model.channel.ChannelItem;
-import com.asyncapi.v2.model.channel.operation.Operation;
-import com.asyncapi.v2.model.server.Server;
+import com.asyncapi.v2._6_0.model.channel.ChannelItem;
+import com.asyncapi.v2._6_0.model.channel.operation.Operation;
+import com.asyncapi.v2._6_0.model.server.Server;
 
 public abstract class AbstractChannelConfigurer implements ChannelConfigurer {
 

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/ChannelConfigurer.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/ChannelConfigurer.java
@@ -2,8 +2,8 @@ package io.quarkiverse.asyncapi.config.channels;
 
 import java.util.Map;
 
-import com.asyncapi.v2.model.channel.ChannelItem;
-import com.asyncapi.v2.model.server.Server;
+import com.asyncapi.v2._6_0.model.channel.ChannelItem;
+import com.asyncapi.v2._6_0.model.server.Server;
 
 public interface ChannelConfigurer {
 

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/ChannelConfigurerFactory.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/ChannelConfigurerFactory.java
@@ -6,7 +6,7 @@ import java.util.ServiceLoader;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import com.asyncapi.v2.model.server.Server;
+import com.asyncapi.v2._6_0.model.server.Server;
 
 public class ChannelConfigurerFactory {
 

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/HttpChannelConfigurer.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/HttpChannelConfigurer.java
@@ -2,8 +2,8 @@ package io.quarkiverse.asyncapi.config.channels;
 
 import java.util.Map;
 
-import com.asyncapi.v2.model.channel.operation.Operation;
-import com.asyncapi.v2.model.server.Server;
+import com.asyncapi.v2._6_0.model.channel.operation.Operation;
+import com.asyncapi.v2._6_0.model.server.Server;
 
 public class HttpChannelConfigurer extends AbstractChannelConfigurer {
 

--- a/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/KafkaChannelConfigurer.java
+++ b/runtime/src/main/java/io/quarkiverse/asyncapi/config/channels/KafkaChannelConfigurer.java
@@ -2,8 +2,8 @@ package io.quarkiverse.asyncapi.config.channels;
 
 import java.util.Map;
 
-import com.asyncapi.v2.model.channel.operation.Operation;
-import com.asyncapi.v2.model.server.Server;
+import com.asyncapi.v2._6_0.model.channel.operation.Operation;
+import com.asyncapi.v2._6_0.model.server.Server;
 
 public class KafkaChannelConfigurer extends AbstractChannelConfigurer {
 


### PR DESCRIPTION
Hi!

I'm glad to see that you are using JAsyncAPI inside your awesome project)

I released a new EAP version with many changes and decided to upgrade your dependency too.

tldr; new bindings, new security schemes, updated schema, AsyncAPI 2.6.0

```shell
➜  quarkus-asyncapi git:(feat/asyncapi_2.6.0) ✗ mvn test 
...
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for Quarkus - AsyncAPI - Parent 1.0.0-SNAPSHOT:
[INFO] 
[INFO] Quarkus - AsyncAPI - Parent ........................ SUCCESS [  1.622 s]
[INFO] Quarkus - AsyncAPI - Runtime ....................... SUCCESS [  6.775 s]
[INFO] Quarkus - AsyncAPI - Deployment .................... SUCCESS [  5.881 s]
[INFO] Quarkus - Async API - Documentation ................ SUCCESS [  0.368 s]
[INFO] Quarkus - Async API -  Tests ....................... SUCCESS [  0.009 s]
[INFO] Quarkus - Async API -  Tests - Simple .............. SUCCESS [  9.638 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  25.674 s
[INFO] Finished at: 2023-03-16T02:00:29+04:00
[INFO] ------------------------------------------------------------------------
```