### PR TITLE
Fix dead guides link in quarkus-extension.yaml

### DIFF
--- a/quarkus-asyncapi-scanner/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/quarkus-asyncapi-scanner/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -2,7 +2,7 @@ name: AsyncAPI Scanner
 metadata:
   keywords:
     - asyncapi
-  guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-asyncapi-annotation-scanner/dev/
+  guide: https://quarkiverse.github.io/quarkiverse-docs/quarkus-asyncapi/dev/scanner.html
   categories:
     - "miscellaneous"
   status: "preview"


### PR DESCRIPTION
The guides link for the asyncapi scanner is broken. This causes a dead link on the asyncapi scanner page on http://quarkus.io/extensions. (The async api scanner page isn't there at the moment, because of the dead doc link, but you get the idea. :) )