### PR TITLE
Fixing dependency error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,11 +42,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>io.quarkus</groupId>
-                <artifactId>quarkus-vertx-http</artifactId>
-                <version>${quarkus.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>${version.org.slf4j}</version>
@@ -72,17 +67,6 @@
                 <groupId>com.asyncapi</groupId>
                 <artifactId>asyncapi-core</artifactId>
                 <version>${version.asyncapi.core}</version>
-            </dependency>
-            <!--Just for Tests Simple Project-->
-            <dependency>
-                <groupId>io.smallrye.reactive</groupId>
-                <artifactId>smallrye-reactive-messaging-api</artifactId>
-                <version>4.5.0</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.microprofile.openapi</groupId>
-                <artifactId>microprofile-openapi-api</artifactId>
-                <version>3.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
Fixing https://github.com/quarkiverse/quarkus-asyncapi/actions/runs/5108638369
The two managed dependencies removed should rely on quarkus version to avoid classnotfound issues